### PR TITLE
Move data-grabber under the actions folder

### DIFF
--- a/.github/workflows/data-grabber.yml
+++ b/.github/workflows/data-grabber.yml
@@ -5,7 +5,7 @@ on:
 
 defaults:
   run:
-    working-direction: actions/data-grabber
+    working-directory: actions/data-grabber
 
 jobs:
   get-weekly-stats:

--- a/.github/workflows/data-grabber.yml
+++ b/.github/workflows/data-grabber.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
       - run: npm install
-      - run: node data-grabber.js
+      - run: node index.js

--- a/.github/workflows/data-grabber.yml
+++ b/.github/workflows/data-grabber.yml
@@ -3,6 +3,10 @@ name: data-getter
 on:
   workflow_dispatch:
 
+defaults:
+  run:
+    working-direction: actions/data-grabber
+
 jobs:
   get-weekly-stats:
     runs-on: ubuntu-latest
@@ -10,4 +14,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
       - run: npm install
-      - run: npm run get-data
+      - run: node data-grabber.js

--- a/actions/data-grabber.js
+++ b/actions/data-grabber.js
@@ -1,15 +1,30 @@
 const puppeteer = require('puppeteer');
 
-(async () => {
-    const browser = await puppeteer.launch({headless: true});
+const downloadData = async (url, elementId) => {
+    const browser = await puppeteer.launch({ headless: true });
     const page = await browser.newPage();
-    await page.goto('https://www.pro-football-reference.com/years/2020/#');
+    await page.goto(url);
 
-    const teamStats = await page.evaluate(() => {
-        table2csv("team_stats");
-        return document.getElementById('csv_team_stats').innerText;
-    });       
-    
-    console.log(teamStats);
+    const data = await page.evaluate(elementId => {
+        console.log(`Inner Text is ${elementId}`)
+        table2csv(elementId);
+        return document.getElementById(`csv_${elementId}`).innerText;
+    }, elementId)
+
     await browser.close();
+    return data;
+}
+
+(async () => {
+    const offensiveStats = await downloadData(
+        'https://www.pro-football-reference.com/years/2020/#', 'team_stats'
+    );
+
+    const playerStats = await downloadData(
+        'https://www.pro-football-reference.com/years/2020/fantasy.htm', 'fantasy'
+    );
+
+    const defensiveStats = await downloadData(
+        'https://www.pro-football-reference.com/years/2020/opp.htm', 'team_stats'
+    );
 })();

--- a/actions/data-grabber/index.js
+++ b/actions/data-grabber/index.js
@@ -1,5 +1,4 @@
 const puppeteer = require('puppeteer');
-//const parsePlayerData = require('../../src/lib/parser/parsePlayerData')
 
 const downloadData = async (url, elementId) => {
     const browser = await puppeteer.launch({ headless: true });
@@ -17,20 +16,15 @@ const downloadData = async (url, elementId) => {
 }
 
 (async () => {
-    // const offensiveStats = await downloadData(
-    //     'https://www.pro-football-reference.com/years/2020/#', 'team_stats'
-    // );
+    const offensiveStats = await downloadData(
+        'https://www.pro-football-reference.com/years/2020/#', 'team_stats'
+    );
 
     const playerStats = await downloadData(
         'https://www.pro-football-reference.com/years/2020/fantasy.htm', 'fantasy'
     );
 
-    //const players = parsePlayerData(playerStats);
-    //console.dir(players);
-
-    // const defensiveStats = await downloadData(
-    //     'https://www.pro-football-reference.com/years/2020/opp.htm', 'team_stats'
-    // );
-
-
+    const defensiveStats = await downloadData(
+        'https://www.pro-football-reference.com/years/2020/opp.htm', 'team_stats'
+    );
 })();

--- a/actions/data-grabber/index.js
+++ b/actions/data-grabber/index.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer');
+//const parsePlayerData = require('../../src/lib/parser/parsePlayerData')
 
 const downloadData = async (url, elementId) => {
     const browser = await puppeteer.launch({ headless: true });
@@ -16,15 +17,20 @@ const downloadData = async (url, elementId) => {
 }
 
 (async () => {
-    const offensiveStats = await downloadData(
-        'https://www.pro-football-reference.com/years/2020/#', 'team_stats'
-    );
+    // const offensiveStats = await downloadData(
+    //     'https://www.pro-football-reference.com/years/2020/#', 'team_stats'
+    // );
 
     const playerStats = await downloadData(
         'https://www.pro-football-reference.com/years/2020/fantasy.htm', 'fantasy'
     );
 
-    const defensiveStats = await downloadData(
-        'https://www.pro-football-reference.com/years/2020/opp.htm', 'team_stats'
-    );
+    //const players = parsePlayerData(playerStats);
+    //console.dir(players);
+
+    // const defensiveStats = await downloadData(
+    //     'https://www.pro-football-reference.com/years/2020/opp.htm', 'team_stats'
+    // );
+
+
 })();


### PR DESCRIPTION
The data grabbing and parsing should not be integrated into the nextjs app. This PR lays the foundation to move the parsing data under the action folder. This helps with the separation of concerns of differentiating between what is automated and what is the web application. 